### PR TITLE
Fix reference to "guys"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ had their own workflow, patches circulated in emails, issues were reported in
 a myriad ways, and if anyone wanted to contribute they had to figure out every
 project's rules.
 
-Then, a handful of guys took the challenge to build an awesome platform and as
+Then, a handful of people took the challenge to build an awesome platform and as
 a consequence of their hard work, their platform _earned_ its hegemony.
 
 Nowadays doing Open Source is infinitely easier thanks to you, GitHub. You've
@@ -48,7 +48,4 @@ Signed,
 - Adam Grant ([@adamjgrant](https://github.com/adamjgrant)), Rails and Front end developer in Cupertino, CA
 - Abdul Hagi ([@ballerabdude](https://github.com/ballerabdude)), Software Developer at Turner Broadcasting
 - Aritra Ghosh Dastidar ([@aritraghoshdastidar] (https://github.com/aritraghoshdastidar)), Growth Hacker at Intuit Inc
-- Vincent Grafé ([@vgrafe](https://github.com/vgrafe)), Developer
-- Jacob Evans ([@jacobtheevans](https://github.com/jacobtheevans)), Developer
-- Rick Wouters ([@raketwissenschaftler](https://github.com/raketwissenschaftler)), Developer
 - *Your signature here*


### PR DESCRIPTION
I strongly disagree with this repo taken within the context of when the announcement came out, but if you're going to make this statement I suggest you change the words from `guys`. It ignores the contributions the early women employees and contractors had on nascent GitHub. Even if you're aiming to congratulate just the all-male founders, the strongest contributions GitHub made for open source didn't really happen until 2010, when Pull Requests, Wikis, and Organizations all shipped.